### PR TITLE
Update telekom.de.json (add note about required mobile phone number)

### DIFF
--- a/entries/t/telekom.de.json
+++ b/entries/t/telekom.de.json
@@ -9,6 +9,7 @@
     "categories": [
       "utilities"
     ],
+    "notes": "Mobile phone number required as fallback when enabling authenticator app.",
     "regions": [
       "de"
     ]


### PR DESCRIPTION
Setting up an authenticator app unfortunately requires providing a mobile phone number as fallback.